### PR TITLE
Improve ordering helpers

### DIFF
--- a/src/ordering/ordering.ts
+++ b/src/ordering/ordering.ts
@@ -7,12 +7,31 @@ export type Order<Fields> = {
   dir?: OrderDir;
 };
 
-export const determineOrderDir = <T extends string = string>(
-  currentField: T,
-  newField?: T,
+export type OrderDirChange<Fields extends string = string> = {
+  currentField: Fields,
+  newField?: Fields,
   currentOrderDir?: OrderDir,
-): OrderDir => {
-  if (currentField !== newField) {
+};
+
+export function determineOrderDir<Fields extends string = string>(orderDirChange: OrderDirChange<Fields>): OrderDir;
+export function determineOrderDir<Fields extends string = string>(
+  currentField: Fields,
+  newField?: Fields,
+  currentOrderDir?: OrderDir,
+): OrderDir;
+/**
+ * Generate an Order dir for the new order field, based on previous order field and direction.
+ */
+export function determineOrderDir<Fields extends string = string>(
+  firstArg: Fields | OrderDirChange<Fields>,
+  newField?: Fields,
+  currentOrderDir?: OrderDir,
+): OrderDir {
+  if (typeof firstArg === 'object') {
+    return determineOrderDir(firstArg.currentField, firstArg.newField, firstArg.currentOrderDir);
+  }
+
+  if (firstArg !== newField) {
     return 'ASC';
   }
 
@@ -22,7 +41,31 @@ export const determineOrderDir = <T extends string = string>(
   };
 
   return currentOrderDir ? newOrderMap[currentOrderDir] : 'ASC';
-};
+}
+
+export function determineOrder<Fields extends string = string>(orderDirChange: OrderDirChange<Fields>): Order<Fields>;
+export function determineOrder<Fields extends string = string>(
+  currentField: Fields,
+  newField?: Fields,
+  currentOrderDir?: OrderDir,
+): Order<Fields>;
+/**
+ * Generate an Order object for the new order field, based on previous order field and direction.
+ */
+export function determineOrder<Fields extends string = string>(
+  firstArg: Fields | OrderDirChange<Fields>,
+  newField?: Fields,
+  currentOrderDir?: OrderDir,
+): Order<Fields> {
+  if (typeof firstArg === 'object') {
+    return determineOrder(firstArg.currentField, firstArg.newField, firstArg.currentOrderDir);
+  }
+
+  return {
+    field: newField,
+    dir: determineOrderDir(firstArg, newField, currentOrderDir),
+  };
+}
 
 export const sortList = <List>(list: List[], { field, dir }: Order<keyof List>) => (
   !field || !dir ? list : list.sort((a, b) => {
@@ -33,6 +76,10 @@ export const sortList = <List>(list: List[], { field, dir }: Order<keyof List>) 
   })
 );
 
+/**
+ * Convert provided order object to string, with the pattern `${order.field}-${order.di}`.
+ * @return - A `string` if the `dir` prop is set, `undefined` otherwise.
+ */
 export const orderToString = <T>(order: Order<T>): string | undefined => (
   order.dir ? `${order.field}-${order.dir}` : undefined
 );

--- a/test/ordering/ordering.test.ts
+++ b/test/ordering/ordering.test.ts
@@ -1,4 +1,4 @@
-import { determineOrder, determineOrderDir, orderToString, stringToOrder } from '../../src';
+import { determineOrder, determineOrderDir, orderToString, sortList, stringToOrder } from '../../src';
 
 describe('ordering', () => {
   describe('determineOrderDir', () => {
@@ -69,6 +69,58 @@ describe('ordering', () => {
       ['bar-DESC', { field: 'bar', dir: 'DESC' }],
     ])('casts a string to an order objects', (order, expectedResult) => {
       expect(stringToOrder(order)).toEqual(expectedResult);
+    });
+  });
+
+  describe('sortList', () => {
+    const list = [
+      { name: 'foo', surname: 'bar' },
+      { name: 'Alice', surname: 'Johnson' },
+      { name: 'John', surname: 'Doe' },
+    ];
+
+    it.each([
+      { field: 'name' as const },
+      { dir: 'ASC' as const },
+    ])('returns list as is when either order field or dir are not set', (order) => {
+      expect(sortList(list, order)).toEqual(list);
+    });
+
+    it.each([
+      {
+        order: { field: 'name' as const, dir: 'ASC' as const },
+        expectedList: [
+          { name: 'Alice', surname: 'Johnson' },
+          { name: 'John', surname: 'Doe' },
+          { name: 'foo', surname: 'bar' },
+        ],
+      },
+      {
+        order: { field: 'name' as const, dir: 'DESC' as const },
+        expectedList: [
+          { name: 'foo', surname: 'bar' },
+          { name: 'John', surname: 'Doe' },
+          { name: 'Alice', surname: 'Johnson' },
+        ],
+      },
+      {
+        order: { field: 'surname' as const, dir: 'ASC' as const },
+        expectedList: [
+          { name: 'John', surname: 'Doe' },
+          { name: 'Alice', surname: 'Johnson' },
+          { name: 'foo', surname: 'bar' },
+        ],
+      },
+      {
+        order: { field: 'surname' as const, dir: 'DESC' as const },
+        expectedList: [
+          { name: 'foo', surname: 'bar' },
+          { name: 'Alice', surname: 'Johnson' },
+          { name: 'John', surname: 'Doe' },
+        ],
+      },
+    ])('orders list based on provided options', ({ order, expectedList }) => {
+      expect(sortList(list, order)).toEqual(expectedList);
     });
   });
 });

--- a/test/ordering/ordering.test.ts
+++ b/test/ordering/ordering.test.ts
@@ -1,4 +1,4 @@
-import { determineOrderDir, orderToString, stringToOrder } from '../../src';
+import { determineOrder, determineOrderDir, orderToString, stringToOrder } from '../../src';
 
 describe('ordering', () => {
   describe('determineOrderDir', () => {
@@ -20,6 +20,35 @@ describe('ordering', () => {
     it('returns undefined when current order field and selected field are equal and current order dir is DESC', () => {
       expect(determineOrderDir('foo', 'foo', 'DESC')).toBeUndefined();
       expect(determineOrderDir('bar', 'bar', 'DESC')).toBeUndefined();
+    });
+
+    it('accepts a single object as argument', () => {
+      expect(determineOrderDir({ newField: 'foo', currentField: 'bar' })).toEqual('ASC');
+      expect(determineOrderDir({ newField: 'foo', currentField: 'foo', currentOrderDir: 'ASC' })).toEqual('DESC');
+    });
+  });
+
+  describe('determineOrder', () => {
+    it('returns ASC when current order field and selected field are different', () => {
+      expect(determineOrder('foo', 'bar')).toEqual({ field: 'bar', dir: 'ASC' });
+      expect(determineOrder('bar', 'foo')).toEqual({ field: 'foo', dir: 'ASC' });
+    });
+
+    it('returns ASC when no current order dir is provided', () => {
+      expect(determineOrder('foo', 'foo')).toEqual({ field: 'foo', dir: 'ASC' });
+      expect(determineOrder('bar', 'bar')).toEqual({ field: 'bar', dir: 'ASC' });
+    });
+
+    it('returns DESC when current order field and selected field are equal and current order dir is ASC', () => {
+      expect(determineOrder('foo', 'foo', 'ASC')).toEqual({ field: 'foo', dir: 'DESC' });
+      expect(determineOrder('bar', 'bar', 'ASC')).toEqual({ field: 'bar', dir: 'DESC' });
+    });
+
+    it('accepts a single object as argument', () => {
+      expect(determineOrder({ newField: 'foo', currentField: 'bar' })).toEqual({ field: 'foo', dir: 'ASC' });
+      expect(determineOrder({ newField: 'foo', currentField: 'foo', currentOrderDir: 'ASC' })).toEqual(
+        { field: 'foo', dir: 'DESC' },
+      );
     });
   });
 


### PR DESCRIPTION
This PR adds a few ordering module improvements:

* Add a new `determineOrder` function, which complements existing `determineOrderDir`, but returns a full `Order` object, instead of just the new dir.
* Overload `determineOrder` and `determineOrderDir` function signatures, so that they can receive arguments individually, or as a single object.
* Add missing tests covering the `sortList` helper function.