### PR TITLE
Card modal

### DIFF
--- a/dev/ThemeToggle.tsx
+++ b/dev/ThemeToggle.tsx
@@ -1,13 +1,12 @@
 import type { FC } from 'react';
-import { useEffect, useState } from 'react';
-import { changeThemeInMarkup, ToggleSwitch } from '../src';
+import { ToggleSwitch, useTheme } from '../src';
 
 export const ThemeToggle: FC = () => {
-  const [checked, setChecked] = useState(false);
+  const [theme, setTheme] = useTheme();
 
-  useEffect(() => {
-    changeThemeInMarkup(checked ? 'dark' : 'light');
-  }, [checked]);
-
-  return <ToggleSwitch checked={checked} onChange={setChecked}>Dark theme</ToggleSwitch>;
+  return (
+    <ToggleSwitch checked={theme === 'dark'} onChange={(checked) => setTheme(checked ? 'dark' : 'light')}>
+      Dark theme
+    </ToggleSwitch>
+  );
 };

--- a/dev/tailwind/feedback/ModalDialogPage.tsx
+++ b/dev/tailwind/feedback/ModalDialogPage.tsx
@@ -1,9 +1,12 @@
+import { clsx } from 'clsx';
 import type { FC } from 'react';
 import { useState } from 'react';
-import { Button } from '../../../src/tailwind';
+import { Button, ModalDialog } from '../../../src/tailwind';
 import { CardModal } from '../../../src/tailwind/feedback/CardModal';
 
 export const ModalDialogPage: FC = () => {
+  const [plainDialogOpen, setPlainDialogOpen] = useState(false);
+
   const [smallOpen, setSmallOpen] = useState(false);
   const [mediumOpen, setMediumOpen] = useState(false);
   const [largeOpen, setLargeOpen] = useState(false);
@@ -20,7 +23,26 @@ export const ModalDialogPage: FC = () => {
   return (
     <div className="tw:flex tw:flex-col tw:gap-y-4">
       <div className="tw:flex tw:flex-col tw:gap-y-2">
-        <h2>Modal dialog sizes</h2>
+        <h2>Plain modal dialog</h2>
+        <div className="tw:flex tw:gap-x-2">
+          <Button onClick={() => setPlainDialogOpen(true)}>Open</Button>
+        </div>
+      </div>
+      <ModalDialog
+        open={plainDialogOpen}
+        onClose={() => setPlainDialogOpen(false)}
+        className={clsx(({
+          'tw:flex tw:w-screen tw:h-screen tw:max-w-screen tw:max-h-screen': plainDialogOpen,
+        }))}
+      >
+        <div className="tw:p-3 tw:bg-white tw:m-auto">
+          <p>Hello</p>
+          <Button className="tw:mt-3" variant="secondary" onClick={() => setPlainDialogOpen(false)}>Close me</Button>
+        </div>
+      </ModalDialog>
+
+      <div className="tw:flex tw:flex-col tw:gap-y-2">
+        <h2>Card modal sizes</h2>
         <div className="tw:flex tw:gap-x-2">
           <Button onClick={() => setSmallOpen(true)}>Small</Button>
           <Button onClick={() => setMediumOpen(true)}>Medium</Button>
@@ -43,7 +65,7 @@ export const ModalDialogPage: FC = () => {
       </CardModal>
 
       <div className="tw:flex tw:flex-col tw:gap-y-2">
-        <h2>Danger dialog</h2>
+        <h2>Danger card modal</h2>
         <div className="tw:flex tw:gap-x-2">
           <Button variant="danger" onClick={() => setDangerOpen(true)}>Danger</Button>
         </div>
@@ -60,7 +82,7 @@ export const ModalDialogPage: FC = () => {
       </CardModal>
 
       <div className="tw:flex tw:flex-col tw:gap-y-2">
-        <h2>Dialog with confirm button</h2>
+        <h2>Card modal with confirm button</h2>
         <div className="tw:flex tw:gap-x-2">
           <Button onClick={() => setConfirmOpen(true)}>Custom confirm</Button>
           <Button onClick={() => setConfirmDisabledOpen(true)}>Confirm disabled</Button>
@@ -100,7 +122,7 @@ export const ModalDialogPage: FC = () => {
       </CardModal>
 
       <div className="tw:flex tw:flex-col tw:gap-y-2">
-        <h2>Dialog with a lot of content</h2>
+        <h2>Card modal with a lot of content</h2>
         <div className="tw:flex tw:gap-x-2">
           <Button onClick={() => setContentOpen(true)}>Open</Button>
         </div>

--- a/dev/tailwind/feedback/ModalDialogPage.tsx
+++ b/dev/tailwind/feedback/ModalDialogPage.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import { useState } from 'react';
-import { Button, ModalDialog } from '../../../src/tailwind';
+import { Button } from '../../../src/tailwind';
+import { CardModal } from '../../../src/tailwind/feedback/CardModal';
 
 export const ModalDialogPage: FC = () => {
   const [smallOpen, setSmallOpen] = useState(false);
@@ -9,6 +10,9 @@ export const ModalDialogPage: FC = () => {
   const [extraLargeOpen, setExtraLargeOpen] = useState(false);
 
   const [dangerOpen, setDangerOpen] = useState(false);
+
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmDisabledOpen, setConfirmDisabledOpen] = useState(false);
   const [dangerConfirmOpen, setDangerConfirmOpen] = useState(false);
 
   const [contentOpen, setContentOpen] = useState(false);
@@ -25,28 +29,27 @@ export const ModalDialogPage: FC = () => {
         </div>
       </div>
 
-      <ModalDialog size="sm" title="Small dialog" open={smallOpen} onClose={() => setSmallOpen(false)}>
+      <CardModal size="sm" title="Small dialog" open={smallOpen} onClose={() => setSmallOpen(false)}>
         Small dialog
-      </ModalDialog>
-      <ModalDialog size="md" title="Medium dialog" open={mediumOpen} onClose={() => setMediumOpen(false)}>
+      </CardModal>
+      <CardModal size="md" title="Medium dialog" open={mediumOpen} onClose={() => setMediumOpen(false)}>
         Medium dialog
-      </ModalDialog>
-      <ModalDialog size="lg" title="Large dialog" open={largeOpen} onClose={() => setLargeOpen(false)}>
+      </CardModal>
+      <CardModal size="lg" title="Large dialog" open={largeOpen} onClose={() => setLargeOpen(false)}>
         Large dialog
-      </ModalDialog>
-      <ModalDialog size="xl" title="Extra large dialog" open={extraLargeOpen} onClose={() => setExtraLargeOpen(false)}>
+      </CardModal>
+      <CardModal size="xl" title="Extra large dialog" open={extraLargeOpen} onClose={() => setExtraLargeOpen(false)}>
         Extra large dialog
-      </ModalDialog>
+      </CardModal>
 
       <div className="tw:flex tw:flex-col tw:gap-y-2">
         <h2>Danger dialog</h2>
         <div className="tw:flex tw:gap-x-2">
           <Button variant="danger" onClick={() => setDangerOpen(true)}>Danger</Button>
-          <Button variant="danger" onClick={() => setDangerConfirmOpen(true)}>Danger with confirm</Button>
         </div>
       </div>
 
-      <ModalDialog
+      <CardModal
         size="md"
         title="Danger dialog"
         variant="danger"
@@ -54,8 +57,38 @@ export const ModalDialogPage: FC = () => {
         onClose={() => setDangerOpen(false)}
       >
         Danger dialog
-      </ModalDialog>
-      <ModalDialog
+      </CardModal>
+
+      <div className="tw:flex tw:flex-col tw:gap-y-2">
+        <h2>Dialog with confirm button</h2>
+        <div className="tw:flex tw:gap-x-2">
+          <Button onClick={() => setConfirmOpen(true)}>Custom confirm</Button>
+          <Button onClick={() => setConfirmDisabledOpen(true)}>Confirm disabled</Button>
+          <Button variant="danger" onClick={() => setDangerConfirmOpen(true)}>Danger with confirm</Button>
+        </div>
+      </div>
+
+      <CardModal
+        size="md"
+        title="Custom confirm"
+        confirmText="Accept the action"
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={() => setConfirmOpen(false)}
+      >
+        Custom confirm text
+      </CardModal>
+      <CardModal
+        size="md"
+        title="Custom disabled"
+        confirmDisabled
+        open={confirmDisabledOpen}
+        onClose={() => setConfirmDisabledOpen(false)}
+        onConfirm={() => setConfirmDisabledOpen(false)}
+      >
+        Custom action is disabled
+      </CardModal>
+      <CardModal
         size="md"
         title="Danger dialog"
         variant="danger"
@@ -64,7 +97,7 @@ export const ModalDialogPage: FC = () => {
         onConfirm={() => setDangerConfirmOpen(false)}
       >
         Danger dialog with confirm buttons
-      </ModalDialog>
+      </CardModal>
 
       <div className="tw:flex tw:flex-col tw:gap-y-2">
         <h2>Dialog with a lot of content</h2>
@@ -73,7 +106,7 @@ export const ModalDialogPage: FC = () => {
         </div>
       </div>
 
-      <ModalDialog
+      <CardModal
         size="md"
         title="Fixed header and footer"
         open={contentOpen}
@@ -132,7 +165,7 @@ export const ModalDialogPage: FC = () => {
             leo.
           </p>
         </div>
-      </ModalDialog>
+      </CardModal>
     </div>
   );
 };

--- a/src/tailwind/feedback/CardModal.tsx
+++ b/src/tailwind/feedback/CardModal.tsx
@@ -67,40 +67,42 @@ export const CardModal: FC<CardModalProps> = ({
       open={open}
       onClose={onClose}
       className={clsx(
-        { 'tw:flex tw:w-screen tw:h-screen tw:max-w-screen tw:max-h-screen tw:px-4': open },
+        { 'tw:flex tw:w-screen tw:h-screen tw:max-w-screen tw:max-h-screen': open },
         className,
       )}
       {...restDialogProps}
     >
-      <Card className={clsx(
-        'tw:m-auto tw:w-full',
-        {
-          'tw:md:w-sm': size === 'sm',
-          'tw:md:w-lg': size === 'md',
-          'tw:md:w-4xl': size === 'lg',
-          'tw:md:w-6xl': size === 'xl',
-        },
-      )}>
-        <Card.Header className="tw:flex tw:items-center tw:justify-between tw:sticky tw:top-0">
-          <h5 className={clsx({ 'tw:text-danger': variant === 'danger' })}>{title}</h5>
-          <CloseButton onClick={onClose} label="Close dialog" />
-        </Card.Header>
-        <Card.Body>{children}</Card.Body>
-        {onConfirm && (
-          <Card.Footer
-            className="tw:flex tw:flex-row-reverse tw:gap-x-2 tw:items-center tw:py-4 tw:sticky tw:bottom-0"
-          >
-            <Button
-              disabled={confirmDisabled}
-              variant={variant === 'danger' ? 'danger' : 'primary'}
-              onClick={onConfirm}
+      <div className="tw:m-auto tw:p-4">
+        <Card className={clsx(
+          'tw:w-full',
+          {
+            'tw:md:w-sm': size === 'sm',
+            'tw:md:w-lg': size === 'md',
+            'tw:md:w-4xl': size === 'lg',
+            'tw:md:w-6xl': size === 'xl',
+          },
+        )}>
+          <Card.Header className="tw:flex tw:items-center tw:justify-between tw:sticky tw:top-0">
+            <h5 className={clsx({ 'tw:text-danger': variant === 'danger' })}>{title}</h5>
+            <CloseButton onClick={onClose} label="Close dialog" />
+          </Card.Header>
+          <Card.Body>{children}</Card.Body>
+          {onConfirm && (
+            <Card.Footer
+              className="tw:flex tw:flex-row-reverse tw:gap-x-2 tw:items-center tw:py-4 tw:sticky tw:bottom-0"
             >
-              {confirmText}
-            </Button>
-            <LinkButton onClick={onClose}>Cancel</LinkButton>
-          </Card.Footer>
-        )}
-      </Card>
+              <Button
+                disabled={confirmDisabled}
+                variant={variant === 'danger' ? 'danger' : 'primary'}
+                onClick={onConfirm}
+              >
+                {confirmText}
+              </Button>
+              <LinkButton onClick={onClose}>Cancel</LinkButton>
+            </Card.Footer>
+          )}
+        </Card>
+      </div>
     </ModalDialog>
   );
 };

--- a/src/tailwind/feedback/CardModal.tsx
+++ b/src/tailwind/feedback/CardModal.tsx
@@ -1,0 +1,106 @@
+import clsx from 'clsx';
+import type { FC } from 'react';
+import { Button, CloseButton } from '../form';
+import { LinkButton } from '../navigation';
+import { Card } from '../surfaces';
+import type { Size } from '../types';
+import type { ModalDialogProps } from './ModalDialog';
+import { ModalDialog } from './ModalDialog';
+
+type CommonCardModalProps = {
+  /** Modal header title */
+  title: string;
+  /** Determines the horizontal size of the dialog */
+  size?: Size | 'xl';
+};
+
+type CoverCardModalProps = CommonCardModalProps & {
+  /**
+   * Cover dialogs have a body that span the whole dialog, and no buttons.
+   * The header overlaps the body with semi-transparent background.
+   */
+  variant: 'cover';
+};
+
+type RegularCardModalProps = CommonCardModalProps & {
+  /** Danger dialogs use danger variants in title and confirm button */
+  variant?: 'default' | 'danger'
+
+  /** Value to display in confirm button. Defaults to 'Confirm' */
+  confirmText?: string;
+  /** Whether the confirm button is disabled or not */
+  confirmDisabled?: boolean;
+
+  /**
+   * A footer with confirm and cancel buttons will be rendered if provided.
+   * Invoked when the confirm button is actioned.
+   */
+  onConfirm?: () => void;
+};
+
+export type CardModalProps = Omit<ModalDialogProps, 'title' | 'size'> & (
+  CoverCardModalProps | RegularCardModalProps
+);
+
+/**
+ * A ModalDialog that renders a Card as its content
+ */
+export const CardModal: FC<CardModalProps> = ({
+  open,
+  onClose,
+  variant = 'default',
+  size = 'md',
+  title,
+  children,
+  className,
+  ...rest
+}) => {
+  const { confirmText = 'Confirm', confirmDisabled, onConfirm, ...restDialogProps } = 'onConfirm' in rest ? rest : {
+    ...rest,
+    confirmText: undefined,
+    confirmDisabled: undefined,
+    onConfirm: undefined,
+  };
+
+  return (
+    <ModalDialog
+      open={open}
+      onClose={onClose}
+      className={clsx(
+        { 'tw:flex tw:w-screen tw:h-screen tw:max-w-screen tw:max-h-screen tw:px-4': open },
+        className,
+      )}
+      {...restDialogProps}
+    >
+      <Card className={clsx(
+        'tw:m-auto tw:w-full',
+        {
+          'tw:md:w-sm': size === 'sm',
+          'tw:md:w-lg': size === 'md',
+          'tw:md:w-4xl': size === 'lg',
+          'tw:md:w-6xl': size === 'xl',
+        },
+      )}>
+        <Card.Header className="tw:flex tw:items-center tw:justify-between tw:sticky tw:top-0">
+          <h5 className={clsx({ 'tw:text-danger': variant === 'danger' })}>{title}</h5>
+          <CloseButton onClick={onClose} label="Close dialog" />
+        </Card.Header>
+        <Card.Body>{children}</Card.Body>
+        {onConfirm && (
+          <Card.Footer
+            className="tw:flex tw:flex-row-reverse tw:gap-x-2 tw:items-center tw:py-4 tw:sticky tw:bottom-0"
+          >
+            <Button
+              disabled={confirmDisabled}
+              variant={variant === 'danger' ? 'danger' : 'primary'}
+              onClick={onConfirm}
+            >
+              {confirmText}
+            </Button>
+            <LinkButton onClick={onClose}>Cancel</LinkButton>
+          </Card.Footer>
+        )}
+      </Card>
+    </ModalDialog>
+  );
+};

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 export const MAIN_COLOR = '#4696e5';
 
 export const MAIN_COLOR_ALPHA = 'rgba(70, 150, 229, 0.4)';
@@ -19,3 +21,13 @@ export const isDarkThemeEnabled = (): boolean => document.querySelector('html')?
 export const getSystemPreferredTheme = (_matchMedia = window.matchMedia.bind(window)): Theme => (
   _matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
 );
+
+export const useTheme = (initialTheme?: Theme) => {
+  const [theme, setTheme] = useState(() => initialTheme ?? getSystemPreferredTheme());
+
+  useEffect(() => {
+    changeThemeInMarkup(theme);
+  }, [theme]);
+
+  return [theme, setTheme] as const;
+};


### PR DESCRIPTION
Split `ModalDialog` into two components:

* `ModalDialog`: a dummy wrapper around `<dialog />` with `dialog.showModal()` capabilities, and the logic to hide the body scroll on open.
* `CardModal` : a wrapper around `ModalDialog` which renders a `Card` as its children.