### PR TITLE
Make all buttons default to type=button when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.8.7] - 2024-04-05
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Add missing `type="button"` in `button` used to reveal password in `RevealablePasswordInput`.
+* Make `Button`, `LinkButton` and `CloseButton` default their `type` to `'button'` instead of `undefined`.
+
+
 ## [0.8.6] - 2024-04-05
 ### Added
 * Add tailwind-based `RevealablePasswordInput` component.

--- a/dev/tailwind/form/ButtonsPage.tsx
+++ b/dev/tailwind/form/ButtonsPage.tsx
@@ -51,6 +51,8 @@ export const ButtonsPage: FC = () => {
         <div className="tw:flex tw:gap-x-2">
           <LinkButton>Link button</LinkButton>
           <CloseButton />
+          <Button type="submit">Submit</Button>
+          <Button to="">Button with link</Button>
         </div>
       </div>
     </div>

--- a/src/tailwind/form/Button.tsx
+++ b/src/tailwind/form/Button.tsx
@@ -4,13 +4,14 @@ import type { LinkProps } from 'react-router';
 import { Link } from 'react-router';
 import type { Size } from '../types';
 
-type RegularButtonProps = Omit<HTMLProps<HTMLButtonElement>, 'size'>;
+type RegularButtonProps = Omit<HTMLProps<HTMLButtonElement>, 'size' | 'type'>;
 type LinkButtonProps = LinkProps;
 
 export type ButtonProps = PropsWithChildren<{
   disabled?: boolean;
   className?: string;
   variant?: 'primary' | 'secondary' | 'danger';
+  type?: HTMLButtonElement['type'];
   size?: Size;
   inline?: boolean;
   solid?: boolean;
@@ -24,9 +25,11 @@ export const Button: FC<ButtonProps> = ({
   size = 'md',
   inline = false,
   solid = false,
+  type: providedType = 'button',
   ...rest
 }) => {
   const Tag = 'to' in rest ? Link : 'button';
+  const type = Tag === Link ? undefined : providedType;
 
   return (
     // @ts-expect-error We are explicitly checking for the `to` prop before using Link
@@ -78,6 +81,7 @@ export const Button: FC<ButtonProps> = ({
         className,
       )}
       disabled={disabled}
+      type={type}
       {...rest}
     >
       {children}

--- a/src/tailwind/form/CloseButton.tsx
+++ b/src/tailwind/form/CloseButton.tsx
@@ -10,6 +10,7 @@ export type CloseButtonProps = {
 
 export const CloseButton: FC<CloseButtonProps> = ({ onClick, label = 'Close' }) => (
   <button
+    type="button"
     onClick={onClick}
     className={clsx(
       'tw:opacity-50 tw:highlight:opacity-80 tw:transition-opacity',

--- a/src/tailwind/form/RevealablePasswordInput.tsx
+++ b/src/tailwind/form/RevealablePasswordInput.tsx
@@ -44,6 +44,7 @@ export const RevealablePasswordInput = forwardRef<HTMLInputElement, RevealablePa
         {...rest}
       />
       <button
+        type="button"
         onClick={togglePasswordRevealed}
         title={passwordRevealed ? 'Hide password' : 'Show password'}
         aria-label={passwordRevealed ? 'Hide password' : 'Show password'}

--- a/src/tailwind/navigation/LinkButton.tsx
+++ b/src/tailwind/navigation/LinkButton.tsx
@@ -4,11 +4,10 @@ import type { Size } from '../types';
 
 export type LinkButtonProps = Omit<HTMLProps<HTMLButtonElement>, 'size' | 'type'> & {
   size?: Size;
-  // HTMLProps<HTMLButtonElement> resolves `type` as `string | undefined`, instead of HTMLButtonElement['type']
   type?: HTMLButtonElement['type'];
 };
 
-export const LinkButton: FC<LinkButtonProps> = ({ className, disabled, size = 'md', ...rest }) => (
+export const LinkButton: FC<LinkButtonProps> = ({ className, disabled, size = 'md', type = 'button', ...rest }) => (
   <button
     className={clsx(
       'tw:inline-flex tw:rounded-md tw:focus-ring',
@@ -22,6 +21,7 @@ export const LinkButton: FC<LinkButtonProps> = ({ className, disabled, size = 'm
       className,
     )}
     disabled={disabled}
+    type={type}
     {...rest}
   />
 );

--- a/test/tailwind/feedback/__snapshots__/CardModal.test.tsx.snap
+++ b/test/tailwind/feedback/__snapshots__/CardModal.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`<CardModal /> > renders expected size 1`] = `
           <button
             aria-label="Close dialog"
             class="tw:opacity-50 tw:highlight:opacity-80 tw:transition-opacity tw:rounded-md tw:focus-ring"
+            type="button"
           >
             <svg
               aria-hidden="true"
@@ -89,6 +90,7 @@ exports[`<CardModal /> > renders expected size 2`] = `
           <button
             aria-label="Close dialog"
             class="tw:opacity-50 tw:highlight:opacity-80 tw:transition-opacity tw:rounded-md tw:focus-ring"
+            type="button"
           >
             <svg
               aria-hidden="true"
@@ -150,6 +152,7 @@ exports[`<CardModal /> > renders expected size 3`] = `
           <button
             aria-label="Close dialog"
             class="tw:opacity-50 tw:highlight:opacity-80 tw:transition-opacity tw:rounded-md tw:focus-ring"
+            type="button"
           >
             <svg
               aria-hidden="true"
@@ -211,6 +214,7 @@ exports[`<CardModal /> > renders expected size 4`] = `
           <button
             aria-label="Close dialog"
             class="tw:opacity-50 tw:highlight:opacity-80 tw:transition-opacity tw:rounded-md tw:focus-ring"
+            type="button"
           >
             <svg
               aria-hidden="true"
@@ -272,6 +276,7 @@ exports[`<CardModal /> > renders expected variant 1`] = `
           <button
             aria-label="Close dialog"
             class="tw:opacity-50 tw:highlight:opacity-80 tw:transition-opacity tw:rounded-md tw:focus-ring"
+            type="button"
           >
             <svg
               aria-hidden="true"
@@ -305,11 +310,13 @@ exports[`<CardModal /> > renders expected variant 1`] = `
         >
           <button
             class="tw:inline-flex tw:rounded-md tw:focus-ring tw:text-brand tw:highlight:text-brand-dark tw:highlight:underline tw:px-3 tw:py-1.5"
+            type="button"
           >
             Cancel
           </button>
           <button
             class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-brand tw:text-brand tw:text-white tw:bg-brand tw:highlight:bg-brand-dark tw:highlight:border-brand-dark tw:highlight:bg-brand"
+            type="button"
           >
             Confirm
           </button>
@@ -348,6 +355,7 @@ exports[`<CardModal /> > renders expected variant 2`] = `
           <button
             aria-label="Close dialog"
             class="tw:opacity-50 tw:highlight:opacity-80 tw:transition-opacity tw:rounded-md tw:focus-ring"
+            type="button"
           >
             <svg
               aria-hidden="true"
@@ -381,11 +389,13 @@ exports[`<CardModal /> > renders expected variant 2`] = `
         >
           <button
             class="tw:inline-flex tw:rounded-md tw:focus-ring tw:text-brand tw:highlight:text-brand-dark tw:highlight:underline tw:px-3 tw:py-1.5"
+            type="button"
           >
             Cancel
           </button>
           <button
             class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring-danger tw:px-3 tw:py-1.5 tw:border-danger tw:text-white tw:bg-danger tw:highlight:bg-danger-dark tw:highlight:border-danger-dark tw:highlight:bg-danger"
+            type="button"
           >
             Confirm
           </button>
@@ -422,6 +432,7 @@ exports[`<CardModal /> > renders expected variant 3`] = `
           <button
             aria-label="Close dialog"
             class="tw:opacity-50 tw:highlight:opacity-80 tw:transition-opacity tw:rounded-md tw:focus-ring"
+            type="button"
           >
             <svg
               aria-hidden="true"

--- a/test/tailwind/form/Button.test.tsx
+++ b/test/tailwind/form/Button.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import type { ButtonProps } from '../../../src/tailwind';
 import { Button } from '../../../src/tailwind';
@@ -31,5 +31,15 @@ describe('<Button />', () => {
   ])('renders as expected based on provided props', (props) => {
     const { container } = setUp(props);
     expect(container).toMatchSnapshot();
+  });
+
+  it.each([
+    { type: undefined, expectedType: 'button' },
+    { type: 'button' as const, expectedType: 'button' },
+    { type: 'submit' as const, expectedType: 'submit' },
+    { type: 'reset' as const, expectedType: 'reset' },
+  ])('defaults type to `button`', ({ type, expectedType }) => {
+    setUp({ type, children: 'The button' });
+    expect(screen.getByRole('button', { name: 'The button' })).toHaveAttribute('type', expectedType);
   });
 });

--- a/test/tailwind/form/__snapshots__/Button.test.tsx.snap
+++ b/test/tailwind/form/__snapshots__/Button.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<Button /> > renders as expected based on provided props 1`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-brand tw:text-brand tw:highlight:text-white tw:highlight:bg-brand"
+    type="button"
   />
 </div>
 `;
@@ -12,6 +13,7 @@ exports[`<Button /> > renders as expected based on provided props 2`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-brand tw:text-brand tw:text-white tw:bg-brand tw:highlight:bg-brand-dark tw:highlight:border-brand-dark tw:highlight:bg-brand"
+    type="button"
   />
 </div>
 `;
@@ -20,6 +22,7 @@ exports[`<Button /> > renders as expected based on provided props 3`] = `
 <div>
   <button
     class="tw:inline-flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-brand tw:text-brand tw:highlight:text-white tw:highlight:bg-brand"
+    type="button"
   />
 </div>
 `;
@@ -29,6 +32,7 @@ exports[`<Button /> > renders as expected based on provided props 4`] = `
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-brand tw:text-brand tw:pointer-events-none tw:opacity-65"
     disabled=""
+    type="button"
   />
 </div>
 `;
@@ -37,6 +41,7 @@ exports[`<Button /> > renders as expected based on provided props 5`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-1.5 tw:py-1 tw:text-sm tw:border-brand tw:text-brand tw:highlight:text-white tw:highlight:bg-brand"
+    type="button"
   />
 </div>
 `;
@@ -45,6 +50,7 @@ exports[`<Button /> > renders as expected based on provided props 6`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-brand tw:text-brand tw:highlight:text-white tw:highlight:bg-brand"
+    type="button"
   />
 </div>
 `;
@@ -53,6 +59,7 @@ exports[`<Button /> > renders as expected based on provided props 7`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-4 tw:py-2 tw:text-lg tw:border-brand tw:text-brand tw:highlight:text-white tw:highlight:bg-brand"
+    type="button"
   />
 </div>
 `;
@@ -61,6 +68,7 @@ exports[`<Button /> > renders as expected based on provided props 8`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-brand tw:text-brand tw:highlight:text-white tw:highlight:bg-brand"
+    type="button"
   />
 </div>
 `;
@@ -69,6 +77,7 @@ exports[`<Button /> > renders as expected based on provided props 9`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-zinc-500 tw:text-zinc-500 tw:highlight:text-white tw:highlight:bg-zinc-500"
+    type="button"
   />
 </div>
 `;
@@ -77,6 +86,7 @@ exports[`<Button /> > renders as expected based on provided props 10`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring-danger tw:px-3 tw:py-1.5 tw:border-danger tw:text-danger tw:highlight:text-white tw:highlight:bg-danger"
+    type="button"
   />
 </div>
 `;
@@ -85,6 +95,7 @@ exports[`<Button /> > renders as expected based on provided props 11`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-brand tw:text-brand tw:text-white tw:bg-brand tw:highlight:bg-brand-dark tw:highlight:border-brand-dark tw:highlight:bg-brand"
+    type="button"
   />
 </div>
 `;
@@ -93,6 +104,7 @@ exports[`<Button /> > renders as expected based on provided props 12`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-zinc-500 tw:text-white tw:bg-zinc-500 tw:highlight:bg-zinc-600 tw:highlight:border-zinc-600 tw:highlight:bg-zinc-500"
+    type="button"
   />
 </div>
 `;
@@ -101,6 +113,7 @@ exports[`<Button /> > renders as expected based on provided props 13`] = `
 <div>
   <button
     class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring-danger tw:px-3 tw:py-1.5 tw:border-danger tw:text-white tw:bg-danger tw:highlight:bg-danger-dark tw:highlight:border-danger-dark tw:highlight:bg-danger"
+    type="button"
   />
 </div>
 `;

--- a/test/tailwind/navigation/LinkButton.test.tsx
+++ b/test/tailwind/navigation/LinkButton.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type { LinkButtonProps } from '../../../src/tailwind';
 import { LinkButton } from '../../../src/tailwind';
 import { checkAccessibility } from '../../__helpers__/accessibility';
@@ -17,5 +17,15 @@ describe('<LinkButton />', () => {
   ])('renders as expected based on provided props', (props) => {
     const { container } = setUp(props);
     expect(container).toMatchSnapshot();
+  });
+
+  it.each([
+    { type: undefined, expectedType: 'button' },
+    { type: 'button' as const, expectedType: 'button' },
+    { type: 'submit' as const, expectedType: 'submit' },
+    { type: 'reset' as const, expectedType: 'reset' },
+  ])('defaults type to `button`', ({ type, expectedType }) => {
+    setUp({ type, children: 'The button' });
+    expect(screen.getByRole('button', { name: 'The button' })).toHaveAttribute('type', expectedType);
   });
 });

--- a/test/tailwind/navigation/__snapshots__/LinkButton.test.tsx.snap
+++ b/test/tailwind/navigation/__snapshots__/LinkButton.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<LinkButton /> > renders as expected based on provided props 1`] = `
 <div>
   <button
     class="tw:inline-flex tw:rounded-md tw:focus-ring tw:text-brand tw:highlight:text-brand-dark tw:highlight:underline tw:px-3 tw:py-1.5"
+    type="button"
   />
 </div>
 `;
@@ -13,6 +14,7 @@ exports[`<LinkButton /> > renders as expected based on provided props 2`] = `
   <button
     class="tw:inline-flex tw:rounded-md tw:focus-ring tw:text-brand tw:highlight:text-brand-dark tw:highlight:underline tw:px-3 tw:py-1.5 tw:pointer-events-none tw:opacity-65"
     disabled=""
+    type="button"
   />
 </div>
 `;
@@ -21,6 +23,7 @@ exports[`<LinkButton /> > renders as expected based on provided props 3`] = `
 <div>
   <button
     class="tw:inline-flex tw:rounded-md tw:focus-ring tw:text-brand tw:highlight:text-brand-dark tw:highlight:underline tw:px-1.5 tw:py-1 tw:text-sm"
+    type="button"
   />
 </div>
 `;
@@ -29,6 +32,7 @@ exports[`<LinkButton /> > renders as expected based on provided props 4`] = `
 <div>
   <button
     class="tw:inline-flex tw:rounded-md tw:focus-ring tw:text-brand tw:highlight:text-brand-dark tw:highlight:underline tw:px-3 tw:py-1.5"
+    type="button"
   />
 </div>
 `;
@@ -37,6 +41,7 @@ exports[`<LinkButton /> > renders as expected based on provided props 5`] = `
 <div>
   <button
     class="tw:inline-flex tw:rounded-md tw:focus-ring tw:text-brand tw:highlight:text-brand-dark tw:highlight:underline tw:px-4 tw:py-2 tw:text-lg"
+    type="button"
   />
 </div>
 `;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
       thresholds: {
         statements: 95,
         branches: 95,
-        functions: 85,
+        functions: 90,
         lines: 95,
       },
     },


### PR DESCRIPTION
Fix components which internally use a `button` tag, so that they set `type="button"` unless another type is explicitly provided.

This fixes a confusing behavior, in which buttons will behave as `type="submit"` when used inside a form, unless they are explicitly set as `type="button"`.

This is specially important in auxiliary buttons, like `CloseButton`, `LinkButtn` or the button to reveal a password in `RevealablePasswordInput`, which use a button tag for accessibility, but it's never expected for them to submit a form.