### PR TITLE
Fix accessibility issues with dropdowns rendering their children even when closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.8.10] - 2025-04-11
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Ensure `DropdownBtn` and `OrderingDropdown` do not render the menu children while it's closed, for performance and accessibility reasons.
+
+
 ## [0.8.9] - 2025-04-09
 ### Added
 * *Nothing*

--- a/src/navigation/DropdownBtn.tsx
+++ b/src/navigation/DropdownBtn.tsx
@@ -40,7 +40,7 @@ export const DropdownBtn: FC<DropdownBtnProps> = ({
       <DropdownToggle size={size} caret={!noCaret} className={toggleClasses} color="primary" {...rest}>
         {text}
       </DropdownToggle>
-      <DropdownMenu className="w-100" end={end} style={menuStyle}>{children}</DropdownMenu>
+      <DropdownMenu className="w-100" end={end} style={menuStyle}>{isOpen && children}</DropdownMenu>
     </Dropdown>
   );
 };

--- a/src/ordering/OrderingDropdown.tsx
+++ b/src/ordering/OrderingDropdown.tsx
@@ -1,7 +1,8 @@
 import { faSortAmountDown as sortDescIcon, faSortAmountUp as sortAscIcon } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { clsx } from 'clsx';
-import { DropdownItem, DropdownMenu, DropdownToggle, UncontrolledDropdown } from 'reactstrap';
+import { Dropdown,DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap';
+import { useToggle } from '../hooks';
 import type { Order, OrderDir } from './ordering';
 import { determineOrderDir } from './ordering';
 
@@ -17,13 +18,14 @@ export type OrderingDropdownProps<T extends string = string> = {
 export function OrderingDropdown<T extends string = string>(
   { items, order, onChange, isButton = true, right = false, prefixed = true }: OrderingDropdownProps<T>,
 ) {
+  const [isOpen, toggle] = useToggle();
   const handleItemClick = (fieldKey: T) => () => {
     const newOrderDir = determineOrderDir(fieldKey, order.field, order.dir);
     onChange(newOrderDir ? fieldKey : undefined, newOrderDir);
   };
 
   return (
-    <UncontrolledDropdown>
+    <Dropdown isOpen={isOpen} toggle={toggle}>
       <DropdownToggle
         caret
         color={isButton ? 'primary' : 'link'}
@@ -37,22 +39,27 @@ export function OrderingDropdown<T extends string = string>(
         {isButton && order.field && <>{prefixed && 'Order by: '}{items[order.field]} - <small>{order.dir ?? 'DESC'}</small></>}
       </DropdownToggle>
       <DropdownMenu end={right} className="w-100" style={!isButton ? { minWidth: '11rem' } : undefined}>
-        {Object.entries(items).map(([fieldKey, fieldValue]) => (
-          <DropdownItem
-            key={fieldKey}
-            active={order.field === fieldKey}
-            onClick={handleItemClick(fieldKey as T)}
-            className="d-flex justify-content-between align-items-center"
-          >
-            {fieldValue as string}
-            {order.field === fieldKey && <FontAwesomeIcon icon={order.dir === 'ASC' ? sortAscIcon : sortDescIcon} />}
-          </DropdownItem>
-        ))}
-        <DropdownItem divider />
-        <DropdownItem disabled={!order.field} onClick={() => onChange()}>
-          <i>Clear selection</i>
-        </DropdownItem>
+        {isOpen && (
+          <>
+            {Object.entries(items).map(([fieldKey, fieldValue]) => (
+              <DropdownItem
+                key={fieldKey}
+                active={order.field === fieldKey}
+                onClick={handleItemClick(fieldKey as T)}
+                className="d-flex justify-content-between align-items-center"
+                tabIndex={-1}
+              >
+                {fieldValue as string}
+                {order.field === fieldKey && <FontAwesomeIcon icon={order.dir === 'ASC' ? sortAscIcon : sortDescIcon} />}
+              </DropdownItem>
+            ))}
+            <DropdownItem divider tag="hr" />
+            <DropdownItem disabled={!order.field} onClick={() => onChange()} tabIndex={-1}>
+              <i>Clear selection</i>
+            </DropdownItem>
+          </>
+        )}
       </DropdownMenu>
-    </UncontrolledDropdown>
+    </Dropdown>
   );
 }

--- a/test/__helpers__/accessibility.ts
+++ b/test/__helpers__/accessibility.ts
@@ -1,6 +1,12 @@
 import axe from 'axe-core';
 
-export const checkAccessibility = async ({ container }: { container: HTMLElement }) => {
-  const result = await axe.run(container);
-  expect(result.violations).toStrictEqual([]);
+type ContainerWrapper = { container: HTMLElement };
+
+type AccessibilityTestSubject = ContainerWrapper | Promise<ContainerWrapper>;
+
+export const checkAccessibility = async (subject: AccessibilityTestSubject) => {
+  const { container } = await subject;
+  const { violations } = await axe.run(container);
+
+  expect(violations).toStrictEqual([]);
 };

--- a/test/navigation/RowDropdownBtn.test.tsx
+++ b/test/navigation/RowDropdownBtn.test.tsx
@@ -24,8 +24,18 @@ describe('<RowDropdownBtn />', () => {
     expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument();
   });
 
-  it('renders expected children', () => {
-    setUp();
+  it('renders expected children only while it is open', async () => {
+    const { user } = setUp({ label: 'The button' });
+
+    // Children are not shown, as it is initially closed
+    expect(screen.queryByText('the children')).not.toBeInTheDocument();
+
+    // After clicking on it, the menu is open, and children are rendered
+    await user.click(screen.getByLabelText('The button'));
     expect(screen.getByText('the children')).toBeInTheDocument();
+
+    // Clicking again will close the menu, removing children
+    await user.click(screen.getByLabelText('The button'));
+    expect(screen.queryByText('the children')).not.toBeInTheDocument();
   });
 });

--- a/test/ordering/OrderingDropdown.test.tsx
+++ b/test/ordering/OrderingDropdown.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import type { OrderingDropdownProps } from '../../src';
 import { OrderingDropdown } from '../../src';
+import { checkAccessibility } from '../__helpers__/accessibility';
 import { renderWithEvents } from '../__helpers__/setUpTest';
 
 describe('<OrderingDropdown />', () => {
@@ -17,10 +18,16 @@ describe('<OrderingDropdown />', () => {
     const { user } = result;
 
     await user.click(screen.getByRole('button'));
-    expect(await screen.findByRole('menu')).toBeInTheDocument();
+    await screen.findByRole('menu');
 
     return result;
   };
+
+  it.each([
+    setUp,
+    // FIXME reactstrap sets tabindex={0} to items, when it should be setting -1. It cannot be overwritten
+    // setUpWithDisplayedMenu,
+  ])('passes a11y checks', (s) => checkAccessibility(s()));
 
   it('properly renders provided list of items', async () => {
     await setUpWithDisplayedMenu();


### PR DESCRIPTION
This PR ensures `DropdownBtn` and `OrderingDropdown` do not render the content of their corresponding `DropdownMenu` while it is closed.