### PR TITLE
Improve useToggle hook so that it can return an ibject instead of a tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* `useToggle` can now return its result as a tuple or as an object, with the former being deprecated.
+* Change focus ring for secondary tailwind-based buttons, to match the button color.
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [0.8.10] - 2025-04-11
 ### Added
 * *Nothing*

--- a/dev/hooks/HooksPage.tsx
+++ b/dev/hooks/HooksPage.tsx
@@ -1,19 +1,25 @@
 import type { FC } from 'react';
-import { useTimeoutToggle } from '../../src';
+import { useTimeoutToggle, useToggle } from '../../src';
 import { Button, Result } from '../../src/tailwind';
 
 export const HooksPage: FC = () => {
-  const [value, toggle] = useTimeoutToggle();
+  const [value, toggleTimeout] = useTimeoutToggle();
+  const { flag, toggle: toggleFlag } = useToggle(false, true);
 
   return (
     <div className="tw:flex tw:flex-col tw:gap-y-4">
       <div className="tw:flex tw:flex-col tw:gap-y-2">
         <h2>useTimeoutToggle</h2>
         <div>
-          <Button onClick={toggle}>Show</Button>
-          {value && (
-            <Result variant="success" className="tw:mt-2">Shown!</Result>
-          )}
+          <Button onClick={toggleTimeout}>Show</Button>
+          {value && <Result variant="success" className="tw:mt-2">Shown!</Result>}
+        </div>
+      </div>
+      <div className="tw:flex tw:flex-col tw:gap-y-2">
+        <h2>useToggle</h2>
+        <div>
+          <Button onClick={toggleFlag}>{flag ? 'Hide': 'Show'}</Button>
+          {flag && <Result variant="success" className="tw:mt-2">Shown!</Result>}
         </div>
       </div>
     </div>

--- a/src/hooks/use-toggle.ts
+++ b/src/hooks/use-toggle.ts
@@ -1,12 +1,31 @@
 import { useCallback, useState } from 'react';
 
-export type ToggleResult = [boolean, () => void, () => void, () => void];
+/** @deprecated */
+export type ToggleResultTuple = [boolean, () => void, () => void, () => void];
 
-export const useToggle = (initialValue = false): ToggleResult => {
+export type ToggleResultObject = {
+  flag: boolean;
+  toggle: () => void;
+  setToTrue: () => void;
+  setToFalse: () => void;
+};
+
+export type ToggleResult = ToggleResultTuple | ToggleResultObject;
+
+/** @deprecated Returning result as tuple is deprecated */
+export function useToggle(initialValue?: boolean, asObject?: false): ToggleResultTuple;
+/**
+ * @param asObject - Whether the result should be returned as an object or as a tuple.
+ *                   Deprecated. Future releases will always return an object.
+ */
+export function useToggle(initialValue: boolean, asObject: true): ToggleResultObject;
+export function useToggle(initialValue = false, asObject = false): ToggleResult {
   const [flag, setFlag] = useState(initialValue);
-  const toggleFlag = useCallback(() => setFlag((prev) => !prev), []);
+  const toggle = useCallback(() => setFlag((prev) => !prev), []);
   const setToTrue = useCallback(() => setFlag(true), []);
   const setToFalse = useCallback(() => setFlag(false), []);
 
-  return [flag, toggleFlag, setToTrue, setToFalse];
-};
+  return asObject
+    ? { flag, toggle, setToTrue, setToFalse }
+    : [flag, toggle, setToTrue, setToFalse];
+}

--- a/src/tailwind/form/Button.tsx
+++ b/src/tailwind/form/Button.tsx
@@ -43,7 +43,8 @@ export const Button: FC<ButtonProps> = ({
         'tw:border tw:rounded-md tw:no-underline',
         'tw:transition-colors',
         {
-          'tw:focus-ring': variant !== 'danger',
+          'tw:focus-ring': variant === 'primary',
+          'tw:focus-ring-secondary': variant === 'secondary',
           'tw:focus-ring-danger': variant === 'danger',
         },
         {

--- a/src/tailwind/tailwind.preset.css
+++ b/src/tailwind/tailwind.preset.css
@@ -157,6 +157,10 @@
     @apply tw:focus-ring-base tw:focus-visible:ring-danger/50;
 }
 
+@utility focus-ring-secondary {
+    @apply tw:focus-ring-base tw:focus-visible:ring-zinc-500/50;
+}
+
 @utility scroll-thin {
     /* Standard. New browsers */
     scrollbar-width: thin;
@@ -172,7 +176,7 @@
 
 @custom-variant highlight {
     &:hover,
-    &:focus {
+    &:focus-visible {
         @slot;
     }
 }

--- a/test/hooks/use-toggle.test.tsx
+++ b/test/hooks/use-toggle.test.tsx
@@ -1,0 +1,68 @@
+import { screen } from '@testing-library/react';
+import type { UserEvent } from '@testing-library/user-event/setup/setup';
+import { useToggle } from '../../src';
+import { renderWithEvents } from '../__helpers__/setUpTest';
+
+describe('useToggle', () => {
+  function FakeComponent({ initialValue }: { initialValue: boolean }) {
+    const { flag, toggle, setToFalse, setToTrue } = useToggle(initialValue, true);
+
+    return (
+      <div>
+        <div data-testid="flag-value">{flag ? 'true' : 'false'}</div>
+        <button data-testid="toggle" onClick={toggle}>Toggle</button>
+        <button data-testid="set-to-true" onClick={setToTrue}>Set to true</button>
+        <button data-testid="set-to-false" onClick={setToFalse}>Set to false</button>
+      </div>
+    );
+  }
+
+  const setUp = (initialValue = false) => renderWithEvents(<FakeComponent initialValue={initialValue} />);
+  const assertValue = (expectedValue: boolean) => {
+    expect(screen.getByTestId('flag-value')).toHaveTextContent(expectedValue ? 'true' : 'false');
+  };
+  const clickButton = async (user: UserEvent, buttonId: 'toggle' | 'set-to-true' | 'set-to-false') => {
+    await user.click(screen.getByTestId(buttonId));
+  };
+
+  it.each([true, false])('sets initial value', (initialValue) => {
+    setUp(initialValue);
+    assertValue(initialValue);
+  });
+
+  it('can toggle the value', async () => {
+    const { user } = setUp();
+
+    assertValue(false);
+    await clickButton(user, 'toggle');
+    assertValue(true);
+    await clickButton(user, 'toggle');
+    assertValue(false);
+    await clickButton(user, 'toggle');
+    assertValue(true);
+  });
+
+  it('can set value to true', async () => {
+    const { user } = setUp();
+
+    assertValue(false);
+    await clickButton(user, 'set-to-true');
+    assertValue(true);
+    await clickButton(user, 'set-to-true');
+    assertValue(true);
+    await clickButton(user, 'set-to-true');
+    assertValue(true);
+  });
+
+  it('can set value to false', async () => {
+    const { user } = setUp(true);
+
+    assertValue(true);
+    await clickButton(user, 'set-to-false');
+    assertValue(false);
+    await clickButton(user, 'set-to-false');
+    assertValue(false);
+    await clickButton(user, 'set-to-false');
+    assertValue(false);
+  });
+});

--- a/test/tailwind/form/__snapshots__/Button.test.tsx.snap
+++ b/test/tailwind/form/__snapshots__/Button.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`<Button /> > renders as expected based on provided props 8`] = `
 exports[`<Button /> > renders as expected based on provided props 9`] = `
 <div>
   <button
-    class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-zinc-500 tw:text-zinc-500 tw:highlight:text-white tw:highlight:bg-zinc-500"
+    class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring-secondary tw:px-3 tw:py-1.5 tw:border-zinc-500 tw:text-zinc-500 tw:highlight:text-white tw:highlight:bg-zinc-500"
     type="button"
   />
 </div>
@@ -103,7 +103,7 @@ exports[`<Button /> > renders as expected based on provided props 11`] = `
 exports[`<Button /> > renders as expected based on provided props 12`] = `
 <div>
   <button
-    class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring tw:px-3 tw:py-1.5 tw:border-zinc-500 tw:text-white tw:bg-zinc-500 tw:highlight:bg-zinc-600 tw:highlight:border-zinc-600 tw:highlight:bg-zinc-500"
+    class="tw:flex tw:gap-2 tw:items-center tw:justify-center tw:border tw:rounded-md tw:no-underline tw:transition-colors tw:focus-ring-secondary tw:px-3 tw:py-1.5 tw:border-zinc-500 tw:text-white tw:bg-zinc-500 tw:highlight:bg-zinc-600 tw:highlight:border-zinc-600 tw:highlight:bg-zinc-500"
     type="button"
   />
 </div>


### PR DESCRIPTION
The `useToggle` hook has traditionally returned a tuple with the flag, and three callbacks, for two main reasons:

1. Follow the `useState` signature as much as possible.
2. Allow you to use any name for the flag and callbacks.

However, it has two main problems:

1. You frequently only want some of the later callbacks, causing a weird array unpacking to skip the middle ones.
2. It's hard to remember in which order are callbacks returned, having to go back to the source frequently.

Because of that, this PR allows `useToggle` to return an object with "named" properties, if a second `true` argument is provided, and deprecates the tuple approach. Tuple approach is still the default for BC.

Future versions will remove the tuple approach and remove the second argument.

This approach has the problem that now you will probably have to alias the properties you want to use, but this is less problematic that the issues listed above.