### PR TITLE
Define bootstrap breakpoints in tailwind preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* Define bootstrap breakpoints in tailwind preset, so that migration can be done progressively.
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [0.8.12] - 2025-04-20
 ### Added
 * *Nothing*

--- a/src/tailwind/tailwind.preset.css
+++ b/src/tailwind/tailwind.preset.css
@@ -50,6 +50,13 @@
     --color-warning: #ffc107;
     --color-warning-dark: #ffca2c;
     --color-placeholder: #6c757d;
+
+    /* Override breakpoints with the values from bootstrap, to keep sizing until fully migrated */
+    --breakpoint-sm: 576px;
+    --breakpoint-md: 768px;
+    --breakpoint-lg: 992px;
+    --breakpoint-xl: 1200px;
+    --breakpoint-2xl: 1400px;
 }
 
 @layer base {


### PR DESCRIPTION
Keeping consistent breakpoints between bootstrap and tailwind will allow for an easier stepped migration.

Once migration is finished we can decide if tailwind default breakpoints should be used.