### PR TITLE
Improve tailwind-based Tooltip component

### DIFF
--- a/dev/tailwind/feedback/TooltipPage.tsx
+++ b/dev/tailwind/feedback/TooltipPage.tsx
@@ -1,13 +1,15 @@
 import type { FC } from 'react';
-import { Tooltip, useTooltip } from '../../../src/tailwind';
+import { Button, Tooltip, useTooltip } from '../../../src/tailwind';
 
 export const TooltipPage: FC = () => {
   const main = useTooltip();
+  const keepOpen = useTooltip();
   const bottom = useTooltip({ placement: 'bottom' });
   const top = useTooltip({ placement: 'top' });
   const left = useTooltip({ placement: 'left' });
   const right = useTooltip({ placement: 'right' });
   const rich = useTooltip();
+  const content = useTooltip();
 
   return (
     <div className="tw:flex tw:flex-col tw:gap-y-4">
@@ -15,6 +17,18 @@ export const TooltipPage: FC = () => {
         <h2>Tooltip</h2>
         <div {...main.anchor} className="tw:border tw:p-2">Hover me</div>
         <Tooltip {...main.tooltip}>Hello!!</Tooltip>
+      </div>
+
+      <div className="tw:flex tw:flex-col tw:gap-y-2">
+        <h2>Tooltip that can be hovered</h2>
+        <div {...keepOpen.anchor} className="tw:border tw:p-2">
+          Hover me
+          <Tooltip {...keepOpen.tooltip}>
+            Hover me too
+            <br />
+            <Button inline size="sm">And click me</Button>
+          </Tooltip>
+        </div>
       </div>
 
       <div className="tw:flex tw:flex-col tw:gap-y-2">
@@ -46,6 +60,21 @@ export const TooltipPage: FC = () => {
           <span className="tw:text-danger">Danger!</span>
           <br />
           Do not do <b>this</b>
+        </Tooltip>
+      </div>
+
+      <div className="tw:flex tw:flex-col tw:gap-y-2">
+        <h2>A lot of content</h2>
+        <div {...content.anchor} className="tw:border tw:p-2">Hover me</div>
+        <Tooltip {...content.tooltip}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc cursus urna et luctus sagittis. Vivamus nibh
+          justo, fringilla ut luctus et, facilisis nec magna. In facilisis lacus sit amet sem mattis consequat. Aenean
+          elementum erat et diam blandit, in efficitur mi pellentesque. Aenean purus quam, venenatis eget orci sit
+          amet,
+          lacinia blandit magna. Curabitur ut eros quis ipsum faucibus bibendum. Sed nibh sem, malesuada nec massa
+          vel,
+          posuere hendrerit justo. Fusce non egestas mauris. Nulla id sapien dapibus, faucibus nunc sed, condimentum
+          leo.
         </Tooltip>
       </div>
     </div>

--- a/src/tailwind/feedback/Tooltip.tsx
+++ b/src/tailwind/feedback/Tooltip.tsx
@@ -1,5 +1,5 @@
 import type { Placement } from '@floating-ui/react';
-import { arrow, autoPlacement, offset, useFloating, useHover, useInteractions,useTransitionStyles  } from '@floating-ui/react';
+import { arrow, autoPlacement, useFloating, useHover, useInteractions, useTransitionStyles } from '@floating-ui/react';
 import { clsx } from 'clsx';
 import type { FC, PropsWithChildren } from 'react';
 import { useMemo, useRef, useState } from 'react';
@@ -14,7 +14,7 @@ export type UseTooltipOptions = {
 export const useTooltip = ({ placement = 'auto' }: UseTooltipOptions = {}) => {
   const arrowRef = useRef<HTMLDivElement>(null);
   const middleware = (() => {
-    const list = [offset(10)];
+    const list = [];
     if (placement === 'auto') {
       list.push(autoPlacement());
     }
@@ -82,31 +82,45 @@ export const Tooltip: FC<TooltipProps> = (
 ) => isMounted && (
   <div
     role="tooltip"
-    className="tw:bg-black/90 tw:text-white tw:text-center tw:px-1.5 tw:py-0.5 tw:rounded"
+    aria-live="polite"
+    className={clsx(
+      'tw:z-1000 tw:max-w-64',
+      // Add space between anchor and tooltip via padding, so that if the tooltip is inside the anchor, you can hover it
+      // and it's never closed
+      {
+        'tw:pt-2.5': arrowSide === 'top',
+        'tw:pb-2.5': arrowSide === 'bottom',
+        'tw:pr-2.5': arrowSide === 'right',
+        'tw:pl-2.5': arrowSide === 'left',
+      },
+    )}
     ref={refSetter}
     style={styles}
     {...rest}
   >
-    {children}
-    <div
-      ref={arrowRef}
-      className={clsx(
-        'tw:absolute',
-        // Render as a triangle
-        'tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90',
-        // Rotate triangle so that it points to the correct direction
-        {
-          'tw:rotate-180': arrowSide === 'bottom',
-          'tw:rotate-90 tw:mr-[-3px]': arrowSide === 'right',
-          'tw:rotate-270 tw:ml-[-3px]': arrowSide === 'left',
-        },
-      )}
-      style={{
-        left: arrowPos?.x,
-        top: arrowPos?.y,
-        [arrowSide]: `${-(arrowRef.current?.offsetWidth ?? 0) / 2}px`,
-      }}
-      data-testid="arrow"
-    />
+    <div className="tw:relative tw:px-1.5 tw:py-1 tw:rounded tw:bg-black/90 tw:text-white tw:text-center">
+      <span className="tw:sr-only">Tooltip: </span>
+      {children}
+      <div
+        ref={arrowRef}
+        className={clsx(
+          'tw:absolute',
+          // Render as a triangle
+          'tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90',
+          // Rotate triangle so that it points to the correct direction
+          {
+            'tw:rotate-180': arrowSide === 'bottom',
+            'tw:rotate-90 tw:mr-[-3px]': arrowSide === 'right',
+            'tw:rotate-270 tw:ml-[-3px]': arrowSide === 'left',
+          },
+        )}
+        style={{
+          left: arrowPos?.x,
+          top: arrowPos?.y,
+          [arrowSide]: `${-(arrowRef.current?.offsetWidth ?? 0) / 2}px`,
+        }}
+        data-testid="arrow"
+      />
+    </div>
   </div>
 );

--- a/test/tailwind/feedback/Tooltip.test.tsx
+++ b/test/tailwind/feedback/Tooltip.test.tsx
@@ -46,8 +46,9 @@ describe('<Tooltip />', () => {
     const { user } = setUp({ placement });
 
     await user.hover(screen.getByTestId('anchor'));
-    await screen.findByRole('tooltip');
+    const tooltip = await screen.findByRole('tooltip');
+    const arrow = screen.getByTestId('arrow');
 
-    expect(screen.getByTestId('arrow').className).toMatchSnapshot();
+    expect(`${tooltip.className}_${arrow.className}`).toMatchSnapshot();
   });
 });

--- a/test/tailwind/feedback/__snapshots__/Tooltip.test.tsx.snap
+++ b/test/tailwind/feedback/__snapshots__/Tooltip.test.tsx.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<Tooltip /> > renders arrow in the proper location based on placement option 1`] = `"tw:absolute tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90 tw:rotate-180"`;
+exports[`<Tooltip /> > renders arrow in the proper location based on placement option 1`] = `"tw:z-1000 tw:max-w-64 tw:pb-2.5_tw:absolute tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90 tw:rotate-180"`;
 
-exports[`<Tooltip /> > renders arrow in the proper location based on placement option 2`] = `"tw:absolute tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90"`;
+exports[`<Tooltip /> > renders arrow in the proper location based on placement option 2`] = `"tw:z-1000 tw:max-w-64 tw:pt-2.5_tw:absolute tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90"`;
 
-exports[`<Tooltip /> > renders arrow in the proper location based on placement option 3`] = `"tw:absolute tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90 tw:rotate-90 tw:mr-[-3px]"`;
+exports[`<Tooltip /> > renders arrow in the proper location based on placement option 3`] = `"tw:z-1000 tw:max-w-64 tw:pr-2.5_tw:absolute tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90 tw:rotate-90 tw:mr-[-3px]"`;
 
-exports[`<Tooltip /> > renders arrow in the proper location based on placement option 4`] = `"tw:absolute tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90 tw:rotate-270 tw:ml-[-3px]"`;
+exports[`<Tooltip /> > renders arrow in the proper location based on placement option 4`] = `"tw:z-1000 tw:max-w-64 tw:pl-2.5_tw:absolute tw:border-l-6 tw:border-r-6 tw:border-b-6 tw:border-l-transparent tw:border-r-transparent tw:border-b-black/90 tw:rotate-270 tw:ml-[-3px]"`;


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-frontend-kit/issues/394

Add some improvements on the Tooltip component that were overlooked in https://github.com/shlinkio/shlink-frontend-kit/pull/482

- A big z-index so that it always renders on top of other elements.
- A sensible max width.
- A bigger vertical padding.
- Change the way spacing is implemented so that Tooltips can be rendered inside their anchors, allowing to keep them open when hovering over the tooltip itself.
- Add `aria-live="polite"` so that screen readers announce the tooltip when opened.