### PR TITLE
Improve tailwind-based Dropdown component

### DIFF
--- a/dev/tailwind/navigation/DropdownPage.tsx
+++ b/dev/tailwind/navigation/DropdownPage.tsx
@@ -73,6 +73,22 @@ export const DropdownPage: FC = () => {
           </Dropdown>
         </div>
       </div>
+
+      <div className="tw:flex tw:flex-col tw:gap-y-2">
+        <h2>Variants</h2>
+        <div className="tw:flex tw:gap-3 tw:flex-wrap tw:items-center">
+          <Dropdown buttonContent="Caretless" caretless>
+            <Dropdown.Item>Foo</Dropdown.Item>
+            <Dropdown.Item>Bar</Dropdown.Item>
+            <Dropdown.Item>Baz</Dropdown.Item>
+          </Dropdown>
+          <Dropdown buttonContent="Link" buttonVariant="link">
+            <Dropdown.Item>Foo</Dropdown.Item>
+            <Dropdown.Item>Bar</Dropdown.Item>
+            <Dropdown.Item>Baz</Dropdown.Item>
+          </Dropdown>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/navigation/DropdownBtn.tsx
+++ b/src/navigation/DropdownBtn.tsx
@@ -15,6 +15,7 @@ export type DropdownBtnProps = PropsWithChildren<Omit<DropdownToggleProps, 'care
   size?: 'sm' | 'md' | 'lg';
 }>;
 
+/** @deprecated */
 export const DropdownBtn: FC<DropdownBtnProps> = ({
   text,
   disabled = false,

--- a/src/tailwind/navigation/Dropdown.tsx
+++ b/src/tailwind/navigation/Dropdown.tsx
@@ -11,6 +11,7 @@ export type DropdownProps = PropsWithChildren<{
   buttonContent: RequiredReactNode;
   buttonSize?: Size;
   buttonClassName?: string;
+  buttonVariant?: 'button' | 'link';
 
   /** Classes to be set on the containing wrapper element */
   containerClassName?: string;
@@ -22,16 +23,21 @@ export type DropdownProps = PropsWithChildren<{
    * Defaults to 'left'.
    */
   menuAlignment?: 'left' | 'right';
+
+  /** Whether to hide the caret or not. Defaults to false */
+  caretless?: boolean;
 }>;
 
 const BaseDropdown: FC<DropdownProps> = ({
   children,
   menuAlignment = 'left',
+  buttonVariant = 'button',
   buttonContent,
   buttonClassName,
   buttonSize = 'md',
   containerClassName,
   menuClassName,
+  caretless,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -94,10 +100,19 @@ const BaseDropdown: FC<DropdownProps> = ({
         aria-expanded={isOpen}
         aria-controls={menuId}
         className={clsx(
-          'tw:flex tw:justify-between tw:items-center tw:gap-x-2',
-          'tw:rounded-md tw:focus-ring',
-          'tw:border tw:border-lm-border tw:dark:border-dm-border tw:bg-lm-primary tw:dark:bg-dm-primary',
+          'tw:flex tw:items-center tw:gap-x-2 tw:focus-ring',
           {
+            'tw:justify-between': !caretless,
+
+            // Button variant
+            'tw:border tw:border-lm-border tw:dark:border-dm-border': buttonVariant === 'button',
+            'tw:rounded-md tw:bg-lm-primary tw:dark:bg-dm-primary': buttonVariant === 'button',
+
+            // Link variant
+            'tw:text-lm-brand tw:dark:text-dm-brand': buttonVariant === 'link',
+            'tw:highlight:text-lm-brand-dark tw:dark:highlight:text-dm-brand-dark tw:highlight:underline': buttonVariant === 'link',
+
+            // Button sizes
             'tw:px-1.5 tw:py-1 tw:text-sm': buttonSize === 'sm',
             'tw:px-3 tw:py-1.5': buttonSize === 'md',
             'tw:px-4 tw:py-2 tw:text-lg': buttonSize === 'lg',
@@ -113,7 +128,7 @@ const BaseDropdown: FC<DropdownProps> = ({
         }}
       >
         {buttonContent}
-        <FontAwesomeIcon icon={faCaretDown} size="xs" />
+        {!caretless && <FontAwesomeIcon icon={faCaretDown} size="xs" />}
       </button>
       {isOpen && (
         <div

--- a/test/hooks/use-arrow-key-navigation.test.tsx
+++ b/test/hooks/use-arrow-key-navigation.test.tsx
@@ -18,7 +18,7 @@ describe('useArrowKeyNavigation', () => {
     });
 
     return (
-      <div ref={container} data-testid="container">
+      <div ref={container}>
         <button data-selected={selected === 0}>One</button>
         <button data-selected={selected === 1}>Two</button>
         <button data-selected={selected === 2}>Three</button>
@@ -73,7 +73,7 @@ describe('useArrowKeyNavigation', () => {
     const { user } = setUp();
 
     // Start by focusing the first element normally
-    await user.type(screen.getByTestId('container'), '{Tab}');
+    await user.tab();
     expectFocusedButton('One');
 
     // Move focus to the next element
@@ -91,7 +91,7 @@ describe('useArrowKeyNavigation', () => {
     const { user } = setUp({ selected: 2 });
 
     // Start by focusing the selected element normally
-    await user.type(screen.getByTestId('container'), '{Tab}');
+    await user.tab();
     expectFocusedButton('Three');
 
     // Move focus to the previous element
@@ -109,7 +109,7 @@ describe('useArrowKeyNavigation', () => {
     const { user } = setUp({ selected: 1, vertical: false });
 
     // Start by focusing the selected element normally
-    await user.type(screen.getByTestId('container'), '{Tab}');
+    await user.tab();
     expectFocusedButton('Two');
 
     // Pressing Up/Down keys won't change focused item
@@ -123,7 +123,7 @@ describe('useArrowKeyNavigation', () => {
     const { user } = setUp({ selected: 1, horizontal: false });
 
     // Start by focusing the selected element normally
-    await user.type(screen.getByTestId('container'), '{Tab}');
+    await user.tab();
     expectFocusedButton('Two');
 
     // Pressing Up/Down keys won't change focused item

--- a/test/tailwind/navigation/Dropdown.test.tsx
+++ b/test/tailwind/navigation/Dropdown.test.tsx
@@ -1,13 +1,13 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react';
-import type { Size } from '../../../src/tailwind';
+import type { DropdownProps } from '../../../src/tailwind';
 import { Dropdown,LabelledInput  } from '../../../src/tailwind';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
 
 describe('<Dropdown />', () => {
-  const setUp = (buttonSize?: Size) => renderWithEvents(
+  const setUp = (props: Pick<DropdownProps, 'buttonSize' | 'buttonVariant' | 'caretless'> = {}) => renderWithEvents(
     <div>
-      <Dropdown buttonContent="Press me" buttonSize={buttonSize}>
+      <Dropdown buttonContent="Press me" {...props}>
         <Dropdown.Item>One</Dropdown.Item>
         <Dropdown.Item>Two</Dropdown.Item>
         <Dropdown.Item>Three</Dropdown.Item>
@@ -57,11 +57,29 @@ describe('<Dropdown />', () => {
   });
 
   it.each([
-    'sm' as const,
-    'md' as const,
-    'lg' as const,
-  ])('renders toggle button with the right size', (buttonSize) => {
-    setUp(buttonSize);
+    { buttonSize: 'sm' as const },
+    { buttonSize: 'md' as const },
+    { buttonSize: 'lg' as const },
+    { buttonVariant: 'button' as const },
+    { buttonVariant: 'link' as const },
+    { caretless: false },
+    { caretless: true },
+  ])('renders toggle button with the right classes based on provided props', (props) => {
+    setUp(props);
     expect(screen.getByRole('button', { name: 'Press me' }).className).toMatchSnapshot();
+  });
+
+  it.each([
+    { props: {} },
+    { props: { caretless: true } },
+    { props: { caretless: false } },
+  ])('renders caret only if caretless is false', ({ props }) => {
+    setUp(props);
+
+    if (!props.caretless) {
+      expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument();
+    } else {
+      expect(screen.queryByRole('img', { hidden: true })).not.toBeInTheDocument();
+    }
   });
 });

--- a/test/tailwind/navigation/Dropdown.test.tsx
+++ b/test/tailwind/navigation/Dropdown.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import type { DropdownProps } from '../../../src/tailwind';
 import { Dropdown,LabelledInput  } from '../../../src/tailwind';
 import { checkAccessibility } from '../../__helpers__/accessibility';
@@ -49,11 +49,12 @@ describe('<Dropdown />', () => {
   });
 
   it('closes menu when focusing away', async () => {
-    await setUpOpened();
+    const { user } = await setUpOpened();
 
     expect(screen.getByRole('menu')).toBeInTheDocument();
-    screen.getByRole('button', { name: 'Other button' }).focus();
-    await waitForElementToBeRemoved(screen.getByRole('menu'));
+    await user.tab(); // Tab to focus the next focusable element, which is outside the menu
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(document.activeElement).toEqual(screen.getByRole('button', { name: 'Other button' }));
   });
 
   it.each([

--- a/test/tailwind/navigation/__snapshots__/Dropdown.test.tsx.snap
+++ b/test/tailwind/navigation/__snapshots__/Dropdown.test.tsx.snap
@@ -1,7 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<Dropdown /> > renders toggle button with the right size 1`] = `"tw:flex tw:justify-between tw:items-center tw:gap-x-2 tw:rounded-md tw:focus-ring tw:border tw:border-lm-border tw:dark:border-dm-border tw:bg-lm-primary tw:dark:bg-dm-primary tw:px-1.5 tw:py-1 tw:text-sm"`;
+exports[`<Dropdown /> > renders toggle button with the right classes based on provided props 1`] = `"tw:flex tw:items-center tw:gap-x-2 tw:focus-ring tw:justify-between tw:border tw:border-lm-border tw:dark:border-dm-border tw:rounded-md tw:bg-lm-primary tw:dark:bg-dm-primary tw:px-1.5 tw:py-1 tw:text-sm"`;
 
-exports[`<Dropdown /> > renders toggle button with the right size 2`] = `"tw:flex tw:justify-between tw:items-center tw:gap-x-2 tw:rounded-md tw:focus-ring tw:border tw:border-lm-border tw:dark:border-dm-border tw:bg-lm-primary tw:dark:bg-dm-primary tw:px-3 tw:py-1.5"`;
+exports[`<Dropdown /> > renders toggle button with the right classes based on provided props 2`] = `"tw:flex tw:items-center tw:gap-x-2 tw:focus-ring tw:justify-between tw:border tw:border-lm-border tw:dark:border-dm-border tw:rounded-md tw:bg-lm-primary tw:dark:bg-dm-primary tw:px-3 tw:py-1.5"`;
 
-exports[`<Dropdown /> > renders toggle button with the right size 3`] = `"tw:flex tw:justify-between tw:items-center tw:gap-x-2 tw:rounded-md tw:focus-ring tw:border tw:border-lm-border tw:dark:border-dm-border tw:bg-lm-primary tw:dark:bg-dm-primary tw:px-4 tw:py-2 tw:text-lg"`;
+exports[`<Dropdown /> > renders toggle button with the right classes based on provided props 3`] = `"tw:flex tw:items-center tw:gap-x-2 tw:focus-ring tw:justify-between tw:border tw:border-lm-border tw:dark:border-dm-border tw:rounded-md tw:bg-lm-primary tw:dark:bg-dm-primary tw:px-4 tw:py-2 tw:text-lg"`;
+
+exports[`<Dropdown /> > renders toggle button with the right classes based on provided props 4`] = `"tw:flex tw:items-center tw:gap-x-2 tw:focus-ring tw:justify-between tw:border tw:border-lm-border tw:dark:border-dm-border tw:rounded-md tw:bg-lm-primary tw:dark:bg-dm-primary tw:px-3 tw:py-1.5"`;
+
+exports[`<Dropdown /> > renders toggle button with the right classes based on provided props 5`] = `"tw:flex tw:items-center tw:gap-x-2 tw:focus-ring tw:justify-between tw:text-lm-brand tw:dark:text-dm-brand tw:highlight:text-lm-brand-dark tw:dark:highlight:text-dm-brand-dark tw:highlight:underline tw:px-3 tw:py-1.5"`;
+
+exports[`<Dropdown /> > renders toggle button with the right classes based on provided props 6`] = `"tw:flex tw:items-center tw:gap-x-2 tw:focus-ring tw:justify-between tw:border tw:border-lm-border tw:dark:border-dm-border tw:rounded-md tw:bg-lm-primary tw:dark:bg-dm-primary tw:px-3 tw:py-1.5"`;
+
+exports[`<Dropdown /> > renders toggle button with the right classes based on provided props 7`] = `"tw:flex tw:items-center tw:gap-x-2 tw:focus-ring tw:border tw:border-lm-border tw:dark:border-dm-border tw:rounded-md tw:bg-lm-primary tw:dark:bg-dm-primary tw:px-3 tw:py-1.5"`;


### PR DESCRIPTION
Improve the `Dropdown` component from https://github.com/shlinkio/shlink-frontend-kit/pull/490

- Add `caretless` prop to conditionally decide not to render the caret.
- Add `buttonVariant` prop to decide if the toggle button should look like a button or a link.
- Add `RowDropdown` component which wraps a `Dropdown` with `caretless=true` and a vertical ellipsis as content.