### PR TITLE
Remove important modifier from tailwind and adjust components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 * Used tailwind classes no longer expect the `tw` prefix.
+* Generated tailwind styles no longer assume are set with important.
 
 ### Deprecated
 * *Nothing*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
-* *Nothing*
+* Add `brandColor()` and `brandColorAlpha()` functions, which resolve the right brand color depending on the active theme.
 
 ### Changed
 * Used tailwind classes no longer expect the `tw` prefix.
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Remove `/tailwind` entry point. All tailwind-based symbols are now exported from the main entry point.
 * Remove dependencies in bootstrap, reactstrap and sass.
 * Remove all symbols and signatures that were deprecated.
+* Remove `MAIN_COLOR` and `MAIN_COLOR_ALPHA` constants. Use `brandColor()` and `brandColorAlpha()` instead.
 
 ### Fixed
 * *Nothing*

--- a/dev/navigation/DropdownPage.tsx
+++ b/dev/navigation/DropdownPage.tsx
@@ -44,9 +44,9 @@ export const DropdownPage: FC = () => {
         <h2>Menu at least as big as button</h2>
         <div>
           <Dropdown buttonContent="Select something from the menu">
-            <Dropdown.Item>Foo</Dropdown.Item>
-            <Dropdown.Item>Bar</Dropdown.Item>
-            <Dropdown.Item>Baz</Dropdown.Item>
+            <Dropdown.Item to="">Foo</Dropdown.Item>
+            <Dropdown.Item to="">Bar</Dropdown.Item>
+            <Dropdown.Item to="">Baz</Dropdown.Item>
           </Dropdown>
         </div>
       </div>

--- a/dev/tailwind.css
+++ b/dev/tailwind.css
@@ -1,2 +1,2 @@
-@import 'tailwindcss' important;
+@import 'tailwindcss';
 @import '../src/tailwind.preset.css';

--- a/src/form/Select.tsx
+++ b/src/form/Select.tsx
@@ -11,38 +11,31 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(({
   className,
   size = 'md',
   feedback,
-  style = {},
   disabled,
   ...rest
 }, ref) => (
   <select
     ref={ref}
     className={clsx(
-      'w-full appearance-none pr-9',
-      'bg-(image:--chevron-down) bg-no-repeat',
+      'w-full rounded-md border appearance-none pr-9',
+      'bg-(image:--chevron-down) bg-no-repeat bg-position-[right_0.75rem_center] bg-size-[16px_12px]',
       {
         'focus-ring': !feedback,
         'focus-ring-danger': feedback === 'error',
-      },
-      'rounded-md border',
-      {
+
         'border-lm-input-border dark:border-dm-input-border': !feedback,
         'border-danger': feedback === 'error',
-      },
-      {
+
         'pl-2 py-1 text-sm': size === 'sm',
         'pl-3 py-1.5': size === 'md',
         'pl-4 py-2 text-xl': size === 'lg',
+
         'bg-lm-disabled-input dark:bg-dm-disabled-input': disabled,
         // Apply different background color when rendered inside a card
         'bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input': !disabled,
       },
       className,
     )}
-    style={{
-      ...style,
-      background: 'right 0.75rem center / 16px 12px',
-    }}
     disabled={disabled}
     {...rest}
   />

--- a/src/form/ToggleSwitch.tsx
+++ b/src/form/ToggleSwitch.tsx
@@ -11,7 +11,7 @@ export const ToggleSwitch = forwardRef<HTMLInputElement, ToggleSwitchProps>(({ c
     className={clsx(
       'rounded-full w-8 h-4',
       'bg-(image:--circle-grey-dark) dark:bg-(image:--circle-grey-light) checked:bg-(image:--circle-white)',
-      'focus-visible:not-checked:bg-(image:--circle-light-blue)',
+      'focus-visible:not-checked:bg-(image:--circle-blue-light)',
       'checked:bg-right transition-[background-position]',
       className,
     )}

--- a/src/tailwind.preset.css
+++ b/src/tailwind.preset.css
@@ -67,7 +67,7 @@
         --circle-grey-dark: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='rgba%280, 0, 0, 0.25%29'/></svg>");
         --circle-grey-light: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='rgba%28255, 255, 255, 0.25%29'/></svg>");
         --circle-white: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='%23fff'/></svg>");
-        --circle-light-blue: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='%2386b7fe'/></svg>");
+        --circle-blue-light: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='3' fill='%2386b7fe'/></svg>");
 
         @apply scheme-normal dark:scheme-dark scroll-auto;
     }
@@ -77,22 +77,11 @@
     }
 
     a {
-        /*
-         * FIXME Set these styles as plain CSS instead of @apply to avoid higher specificity.
-         *       This can be set via @apply as soon as we stop using important for tailwind classes, once bootstrap is
-         *       removed
-         */
-        color: var(--color-lm-brand);
-        border-radius: var(--radius-xs);
-
         @apply
+            text-lm-brand dark:text-dm-brand rounded-xs
             focus-visible:outline-3 focus-visible:outline-offset-3
             focus-visible:outline-lm-brand/50 dark:focus-visible:outline-dm-brand/50
             focus-visible:z-1;
-    }
-
-    [data-theme="dark"] a {
-        color: var(--color-dm-brand);
     }
 
     h1 {
@@ -118,10 +107,6 @@
         @apply my-3 border-lm-border dark:border-dm-border;
     }
 
-    p {
-        @apply m-0;
-    }
-
     code {
         @apply text-sm text-pink-600 dark:text-pink-500 font-mono;
     }
@@ -132,6 +117,10 @@
 
     summary {
         @apply cursor-pointer;
+    }
+
+    dialog {
+        @apply outline-none
     }
 }
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,15 +1,18 @@
 import { useEffect, useState } from 'react';
 
-export const MAIN_COLOR = '#4696e5';
+export const BRAND_COLOR_DM = '#4696e5';
+export const BRAND_COLOR_ALPHA_DM = 'rgba(70, 150, 229, 0.4)';
 
-export const MAIN_COLOR_ALPHA = 'rgba(70, 150, 229, 0.4)';
+export const BRAND_COLOR_LM = '#2078CF';
+export const BRAND_COLOR_ALPHA_LM = 'rgba(32, 120, 207, 0.4)';
+
+export const brandColor = () => isDarkThemeEnabled() ? BRAND_COLOR_DM : BRAND_COLOR_LM;
+export const brandColorAlpha = () => isDarkThemeEnabled() ? BRAND_COLOR_ALPHA_DM : BRAND_COLOR_ALPHA_LM;
 
 export const HIGHLIGHTED_COLOR = '#f77f28';
-
 export const HIGHLIGHTED_COLOR_ALPHA = 'rgba(247, 127, 40, 0.4)';
 
 export const PRIMARY_LIGHT_COLOR = 'white';
-
 export const PRIMARY_DARK_COLOR = '#161b22';
 
 export type Theme = 'dark' | 'light';

--- a/test/form/__snapshots__/Select.test.tsx.snap
+++ b/test/form/__snapshots__/Select.test.tsx.snap
@@ -3,8 +3,7 @@
 exports[`<Select /> > renders as expected based on provided props 1`] = `
 <div>
   <select
-    class="w-full appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat focus-ring rounded-md border border-lm-input-border dark:border-dm-input-border pl-3 py-1.5 bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
-    style="background: right 0.75rem center / 16px 12px;"
+    class="w-full rounded-md border appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat bg-position-[right_0.75rem_center] bg-size-[16px_12px] focus-ring border-lm-input-border dark:border-dm-input-border pl-3 py-1.5 bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
   >
     <option>
       Foo
@@ -19,8 +18,7 @@ exports[`<Select /> > renders as expected based on provided props 1`] = `
 exports[`<Select /> > renders as expected based on provided props 2`] = `
 <div>
   <select
-    class="w-full appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat focus-ring rounded-md border border-lm-input-border dark:border-dm-input-border pl-2 py-1 text-sm bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
-    style="background: right 0.75rem center / 16px 12px;"
+    class="w-full rounded-md border appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat bg-position-[right_0.75rem_center] bg-size-[16px_12px] focus-ring border-lm-input-border dark:border-dm-input-border pl-2 py-1 text-sm bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
   >
     <option>
       Foo
@@ -35,8 +33,7 @@ exports[`<Select /> > renders as expected based on provided props 2`] = `
 exports[`<Select /> > renders as expected based on provided props 3`] = `
 <div>
   <select
-    class="w-full appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat focus-ring rounded-md border border-lm-input-border dark:border-dm-input-border pl-3 py-1.5 bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
-    style="background: right 0.75rem center / 16px 12px;"
+    class="w-full rounded-md border appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat bg-position-[right_0.75rem_center] bg-size-[16px_12px] focus-ring border-lm-input-border dark:border-dm-input-border pl-3 py-1.5 bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
   >
     <option>
       Foo
@@ -51,8 +48,7 @@ exports[`<Select /> > renders as expected based on provided props 3`] = `
 exports[`<Select /> > renders as expected based on provided props 4`] = `
 <div>
   <select
-    class="w-full appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat focus-ring rounded-md border border-lm-input-border dark:border-dm-input-border pl-4 py-2 text-xl bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
-    style="background: right 0.75rem center / 16px 12px;"
+    class="w-full rounded-md border appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat bg-position-[right_0.75rem_center] bg-size-[16px_12px] focus-ring border-lm-input-border dark:border-dm-input-border pl-4 py-2 text-xl bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
   >
     <option>
       Foo
@@ -67,8 +63,7 @@ exports[`<Select /> > renders as expected based on provided props 4`] = `
 exports[`<Select /> > renders as expected based on provided props 5`] = `
 <div>
   <select
-    class="w-full appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat focus-ring-danger rounded-md border border-danger pl-3 py-1.5 bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
-    style="background: right 0.75rem center / 16px 12px;"
+    class="w-full rounded-md border appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat bg-position-[right_0.75rem_center] bg-size-[16px_12px] focus-ring-danger border-danger pl-3 py-1.5 bg-lm-primary dark:bg-dm-primary group-[&]/card:bg-lm-input group-[&]/card:dark:bg-dm-input"
   >
     <option>
       Foo
@@ -83,9 +78,8 @@ exports[`<Select /> > renders as expected based on provided props 5`] = `
 exports[`<Select /> > renders as expected based on provided props 6`] = `
 <div>
   <select
-    class="w-full appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat focus-ring rounded-md border border-lm-input-border dark:border-dm-input-border pl-3 py-1.5 bg-lm-disabled-input dark:bg-dm-disabled-input"
+    class="w-full rounded-md border appearance-none pr-9 bg-(image:--chevron-down) bg-no-repeat bg-position-[right_0.75rem_center] bg-size-[16px_12px] focus-ring border-lm-input-border dark:border-dm-input-border pl-3 py-1.5 bg-lm-disabled-input dark:bg-dm-disabled-input"
     disabled=""
-    style="background: right 0.75rem center / 16px 12px;"
   >
     <option>
       Foo


### PR DESCRIPTION
Closes #401
Closes #3

Remove `important` modifier from dev tailwind stylesheet, and adjust components so that they do not assume classes are set with `!important`.