### PR TITLE
Ensure dropdown menus are kept inside the viewport by shifting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * *Nothing*
 
 ### Removed
-* *Nothing*
+* Drop support for React Router 7
 
 ### Fixed
-* *Nothing*
+* Ensure dropdown menus are shifted to be kept inside the viewport when needed.
 
 
 ## [1.5.0] - 2026-06-20

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "clsx": "^2.1.1"
       },
       "devDependencies": {
-        "@shlinkio/eslint-config-js-coding-standard": "~4.0.0",
+        "@shlinkio/eslint-config-js-coding-standard": "~4.1.0",
         "@storybook/addon-docs": "^10.5.5",
         "@storybook/react-vite": "^10.5.5",
         "@tailwindcss/vite": "^4.3.3",
@@ -2768,9 +2768,9 @@
       }
     },
     "node_modules/@shlinkio/eslint-config-js-coding-standard": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@shlinkio/eslint-config-js-coding-standard/-/eslint-config-js-coding-standard-4.0.0.tgz",
-      "integrity": "sha512-D6T2Y8eCFC6p/Vg69yxQUo8a1F1JxOssktpaO8oSjrsW7UJbbfUyvWU8r11pasvU+7xpgtG7WD1IN4mVv38f0g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shlinkio/eslint-config-js-coding-standard/-/eslint-config-js-coding-standard-4.1.0.tgz",
+      "integrity": "sha512-ZIJBZzFkC1T397UcAOLgHw6BkxJ8AorvRvCsjUnaWP/rqGHKN53HwqzH9VBNA9mUHe+syuLlEAfV+grx5zjFHQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@fortawesome/react-fontawesome": "^3.0.0",
     "react": "^19.1",
     "react-dom": "^19.1",
-    "react-router": "^8.0.1 || ^7.0.2",
+    "react-router": "^8.0.1",
     "tailwindcss": "^4.0.1"
   },
   "peerDependenciesMeta": {
@@ -61,7 +61,7 @@
     }
   },
   "devDependencies": {
-    "@shlinkio/eslint-config-js-coding-standard": "~4.0.0",
+    "@shlinkio/eslint-config-js-coding-standard": "~4.1.0",
     "@storybook/addon-docs": "^10.5.5",
     "@storybook/react-vite": "^10.5.5",
     "@tailwindcss/vite": "^4.3.3",

--- a/src/navigation/Dropdown.tsx
+++ b/src/navigation/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { flip, offset, useClick, useFloating, useInteractions } from '@floating-ui/react';
+import { flip, offset, shift, useClick, useFloating, useInteractions } from '@floating-ui/react';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { clsx } from 'clsx';
@@ -60,7 +60,7 @@ const BaseDropdown: FC<DropdownProps> = ({
     open: isOpen,
     onOpenChange: setIsOpen,
     placement: menuAlignment === 'right' ? 'bottom-end' : 'bottom-start',
-    middleware: [flip(), offset(menuOffset)],
+    middleware: [flip(), shift({ mainAxis: false, crossAxis: true }), offset(menuOffset)],
     // oxlint-disable-next-line react-compiler/react-compiler
     elements: { reference: buttonRef.current },
   });


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/982

So far, if there was not enough space below a dropdown button, the menu would render above.

However, if the space above is bigger but still not enough, the menu would be cropped, making it impossioble to interact with it in full.

This PR changes that, so that the menu is shifted if not enough space exist above, overlapping the button when needed, and ensuring regular page scroll will allow to interact with the whole menu.